### PR TITLE
Fix build on x86_64 linux machines

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -60,7 +60,7 @@ else:
     if platform.system() == 'Darwin':
         extra_compile_args = ['-msse4.2', '-mcrc']  # universal2
     elif platform.system() == 'Linux':
-        if platform.processor() == 'x86_64':
+        if platform.machine() == 'x86_64':
             extra_compile_args = ['-msse4.2']
         else:
             # Raspberry Pi 4 does not support CRC acceleration


### PR DESCRIPTION
Hi,
on my machine (Archlinux, python 3.11.6), correct flags (`-msse4.2`) were not added.
Output of my platform info:
```
platform.system() -> "Linux"
platform.machine() -> "x86_64"
platform.processor() -> ""
```
Decision has to be done based on output of `platform.machine()` and not `platform.processor()`

Does it also work in you case?